### PR TITLE
Revert "flatpak: Run with --interactive by default"

### DIFF
--- a/org.gnome.Screenshot.json
+++ b/org.gnome.Screenshot.json
@@ -3,7 +3,10 @@
     "runtime" : "org.gnome.Platform",
     "runtime-version" : "master",
     "sdk" : "org.gnome.Sdk",
-    "command" : "gnome-screenshot-interactive",
+    "command" : "gnome-screenshot",
+    "x-run-args" : [
+        "--interactive"
+    ],
     "finish-args" : [
         "--share=ipc",
         "--socket=x11",
@@ -39,23 +42,6 @@
                 {
                     "type" : "git",
                     "url" : "https://gitlab.gnome.org/GNOME/libhandy.git"
-                }
-            ]
-        },
-        {
-            "name" : "gnome-screenshot-interactive",
-            "buildsystem" : "simple",
-            "build-commands" : [
-                "mkdir -p /app/bin/",
-                "install -m755 -pD gnome-screenshot-interactive /app/bin/gnome-screenshot-interactive"
-            ],
-            "sources" : [
-                {
-                    "type" : "script",
-                    "commands" : [
-                        "gnome-screenshot -i"
-                    ],
-                    "dest-filename" : "gnome-screenshot-interactive"
                 }
             ]
         },


### PR DESCRIPTION
This reverts commit dfcff1507869af629ee62a147a9679adc2c3d36b.